### PR TITLE
Fixes before release 1.0.5

### DIFF
--- a/src/Akka.Persistence.SqlServer.Tests/Akka.Persistence.SqlServer.Tests.csproj
+++ b/src/Akka.Persistence.SqlServer.Tests/Akka.Persistence.SqlServer.Tests.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -50,28 +49,28 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Akka, Version=1.0.5.111, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Akka.1.0.5.111-beta\lib\net45\Akka.dll</HintPath>
+    <Reference Include="Akka, Version=1.0.5.14, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.1.0.5\lib\net45\Akka.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Akka.Persistence, Version=1.0.5.111, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Akka.Persistence.1.0.5.111-beta\lib\net45\Akka.Persistence.dll</HintPath>
+    <Reference Include="Akka.Persistence, Version=1.0.5.15, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.Persistence.1.0.5.15-beta\lib\net45\Akka.Persistence.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Akka.Persistence.Sql.Common, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Akka.Persistence.Sql.Common.1.0.5.111-beta\lib\net45\Akka.Persistence.Sql.Common.dll</HintPath>
+      <HintPath>..\packages\Akka.Persistence.Sql.Common.1.0.5.15-beta\lib\net45\Akka.Persistence.Sql.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Akka.Persistence.TestKit, Version=1.0.5.111, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Akka.Persistence.TestKit.1.0.5.111-beta\lib\net45\Akka.Persistence.TestKit.dll</HintPath>
+    <Reference Include="Akka.Persistence.TestKit, Version=1.0.5.15, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.Persistence.TestKit.1.0.5.15-beta\lib\net45\Akka.Persistence.TestKit.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Akka.TestKit, Version=1.0.5.111, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Akka.TestKit.1.0.5.111-beta\lib\net45\Akka.TestKit.dll</HintPath>
+    <Reference Include="Akka.TestKit, Version=1.0.5.14, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.TestKit.1.0.5\lib\net45\Akka.TestKit.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Akka.TestKit.Xunit2, Version=1.0.5.111, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Akka.TestKit.Xunit2.1.0.5.111-beta\lib\net45\Akka.TestKit.Xunit2.dll</HintPath>
+    <Reference Include="Akka.TestKit.Xunit2, Version=1.0.5.14, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.TestKit.Xunit2.1.0.5\lib\net45\Akka.TestKit.Xunit2.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.ProtocolBuffers, Version=2.4.1.521, Culture=neutral, PublicKeyToken=55f7125234beb589, processorArchitecture=MSIL">
@@ -81,8 +80,8 @@
     <Reference Include="Google.ProtocolBuffers.Serialization">
       <HintPath>..\packages\Google.ProtocolBuffers.2.4.1.521\lib\net40\Google.ProtocolBuffers.Serialization.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.1-beta3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -93,20 +92,20 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="Wire, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Wire.0.0.4\lib\Wire.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.assert, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.assert.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.core, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
+    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -118,12 +117,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SqlServerJournalSpec.cs" />
     <Compile Include="SqlServerSnapshotStoreSpec.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Akka.Persistence.SqlServer\Akka.Persistence.SqlServer.csproj">
-      <Project>{bac85686-afc4-413e-98dc-5ed8f468bc63}</Project>
-      <Name>Akka.Persistence.SqlServer</Name>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include=".NETFramework,Version=v4.5">
@@ -143,17 +136,23 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <ProjectReference Include="..\Akka.Persistence.SqlServer\Akka.Persistence.SqlServer.csproj">
+      <Project>{bac85686-afc4-413e-98dc-5ed8f468bc63}</Project>
+      <Name>Akka.Persistence.SqlServer</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-    <Error Condition="!Exists('..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
   </Target>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Akka.Persistence.SqlServer.Tests/DbUtils.cs
+++ b/src/Akka.Persistence.SqlServer.Tests/DbUtils.cs
@@ -6,7 +6,7 @@ namespace Akka.Persistence.SqlServer.Tests
 {
     public static class DbUtils
     {
-       
+
         public static void Initialize()
         {
             var connectionString = ConfigurationManager.ConnectionStrings["TestDb"].ConnectionString;
@@ -34,19 +34,32 @@ namespace Akka.Persistence.SqlServer.Tests
 
                     var result = cmd.ExecuteScalar();
                 }
+
+                DropTables(conn, databaseName);
             }
         }
 
         public static void Clean()
         {
             var connectionString = ConfigurationManager.ConnectionStrings["TestDb"].ConnectionString;
+            var connectionBuilder = new SqlConnectionStringBuilder(connectionString);
+            var databaseName = connectionBuilder.InitialCatalog;
             using (var conn = new SqlConnection(connectionString))
-            using (var cmd = new SqlCommand())
             {
                 conn.Open();
-                cmd.CommandText = @"
-                    IF EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND TABLE_NAME = 'EventJournal') BEGIN DELETE FROM dbo.EventJournal END;
-                    IF EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND TABLE_NAME = 'SnapshotStore') BEGIN DELETE FROM dbo.SnapshotStore END";
+                DropTables(conn, databaseName);
+            }
+        }
+
+        private static void DropTables(SqlConnection conn, string databaseName)
+        {
+            using (var cmd = new SqlCommand())
+            {
+                cmd.CommandText = string.Format(@"
+                    USE {0};
+                    IF EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND TABLE_NAME = 'EventJournal') BEGIN DROP TABLE dbo.EventJournal END;
+                    IF EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND TABLE_NAME = 'SnapshotStore') BEGIN DROP TABLE dbo.SnapshotStore END;",
+                    databaseName);
                 cmd.Connection = conn;
                 cmd.ExecuteNonQuery();
             }

--- a/src/Akka.Persistence.SqlServer.Tests/SqlServerJournalSpec.cs
+++ b/src/Akka.Persistence.SqlServer.Tests/SqlServerJournalSpec.cs
@@ -24,7 +24,7 @@ namespace Akka.Persistence.SqlServer.Tests
                                 table-name = EventJournal
                                 schema-name = dbo
                                 auto-initialize = on
-                                connection-string = ""Data Source=localhost\\SQLEXPRESS;Database=akka_persistence_tests;User Id=akkadotnet;Password=akkadotnet;""
+                                connection-string-name = ""TestDb""
                             }
                         }
                     }";
@@ -39,7 +39,6 @@ namespace Akka.Persistence.SqlServer.Tests
         public SqlServerJournalSpec(ITestOutputHelper output)
             : base(SpecConfig, "SqlServerJournalSpec", output)
         {
-            DbUtils.Clean();
             Initialize();
         }
 

--- a/src/Akka.Persistence.SqlServer.Tests/SqlServerSnapshotStoreSpec.cs
+++ b/src/Akka.Persistence.SqlServer.Tests/SqlServerSnapshotStoreSpec.cs
@@ -24,7 +24,7 @@ namespace Akka.Persistence.SqlServer.Tests
                                     table-name = SnapshotStore
                                     schema-name = dbo
                                     auto-initialize = on
-                                    connection-string = ""Data Source=localhost\\SQLEXPRESS;Database=akka_persistence_tests;User Id=akkadotnet;Password=akkadotnet;""
+                                    connection-string-name = ""TestDb""
                                 }
                             }
                         }";
@@ -39,7 +39,6 @@ namespace Akka.Persistence.SqlServer.Tests
         public SqlServerSnapshotStoreSpec(ITestOutputHelper output)
             : base(SpecConfig, "SqlServerSnapshotStoreSpec", output)
         {
-            DbUtils.Clean();
             Initialize();
         }
 

--- a/src/Akka.Persistence.SqlServer.Tests/app.config
+++ b/src/Akka.Persistence.SqlServer.Tests/app.config
@@ -10,16 +10,12 @@
         <bindingRedirect oldVersion="0.0.0.0-2.4.1.555" newVersion="2.4.1.555" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="xunit.core" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.0.2929" newVersion="2.0.0.2929" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.0.3179" newVersion="2.1.0.3179" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="xunit.assert" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.0.2929" newVersion="2.0.0.2929" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.0.3179" newVersion="2.1.0.3179" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/Akka.Persistence.SqlServer.Tests/packages.config
+++ b/src/Akka.Persistence.SqlServer.Tests/packages.config
@@ -1,16 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Akka" version="1.0.5.111-beta" targetFramework="net45" />
-  <package id="Akka.Persistence" version="1.0.5.111-beta" targetFramework="net45" />
-  <package id="Akka.Persistence.Sql.Common" version="1.0.5.111-beta" targetFramework="net45" />
-  <package id="Akka.Persistence.TestKit" version="1.0.5.111-beta" targetFramework="net45" />
-  <package id="Akka.TestKit" version="1.0.5.111-beta" targetFramework="net45" />
-  <package id="Akka.TestKit.Xunit2" version="1.0.5.111-beta" targetFramework="net45" />
+  <package id="Akka" version="1.0.5" targetFramework="net45" />
+  <package id="Akka.Persistence" version="1.0.5.15-beta" targetFramework="net45" />
+  <package id="Akka.Persistence.Sql.Common" version="1.0.5.15-beta" targetFramework="net45" />
+  <package id="Akka.Persistence.TestKit" version="1.0.5.15-beta" targetFramework="net45" />
+  <package id="Akka.TestKit" version="1.0.5" targetFramework="net45" />
+  <package id="Akka.TestKit.Xunit2" version="1.0.5" targetFramework="net45" />
   <package id="Google.ProtocolBuffers" version="2.4.1.555" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
-  <package id="Wire" version="0.0.6" targetFramework="net45" />
+  <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.assert" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.core" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
 </packages>

--- a/src/Akka.Persistence.SqlServer/Akka.Persistence.SqlServer.csproj
+++ b/src/Akka.Persistence.SqlServer/Akka.Persistence.SqlServer.csproj
@@ -32,16 +32,16 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Akka, Version=1.0.5.111, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Akka.1.0.5.111-beta\lib\net45\Akka.dll</HintPath>
+    <Reference Include="Akka, Version=1.0.5.14, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.1.0.5\lib\net45\Akka.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Akka.Persistence, Version=1.0.5.111, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Akka.Persistence.1.0.5.111-beta\lib\net45\Akka.Persistence.dll</HintPath>
+    <Reference Include="Akka.Persistence, Version=1.0.5.15, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.Persistence.1.0.5.15-beta\lib\net45\Akka.Persistence.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Akka.Persistence.Sql.Common, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Akka.Persistence.Sql.Common.1.0.5.111-beta\lib\net45\Akka.Persistence.Sql.Common.dll</HintPath>
+      <HintPath>..\packages\Akka.Persistence.Sql.Common.1.0.5.15-beta\lib\net45\Akka.Persistence.Sql.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.ProtocolBuffers, Version=2.4.1.521, Culture=neutral, PublicKeyToken=55f7125234beb589, processorArchitecture=MSIL">
@@ -55,6 +55,7 @@
       <HintPath>..\Packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/Akka.Persistence.SqlServer/Extension.cs
+++ b/src/Akka.Persistence.SqlServer/Extension.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Configuration;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Persistence.Sql.Common;
@@ -74,12 +75,20 @@ namespace Akka.Persistence.SqlServer
 
             if (JournalSettings.AutoInitialize)
             {
-                SqlServerInitializer.CreateSqlServerJournalTables(JournalSettings.ConnectionString, JournalSettings.SchemaName, JournalSettings.TableName);
+                var connectionString = string.IsNullOrEmpty(JournalSettings.ConnectionString)
+                    ? ConfigurationManager.ConnectionStrings[JournalSettings.ConnectionStringName].ConnectionString
+                    : JournalSettings.ConnectionString;
+
+                SqlServerInitializer.CreateSqlServerJournalTables(connectionString, JournalSettings.SchemaName, JournalSettings.TableName);
             }
 
             if (SnapshotSettings.AutoInitialize)
             {
-                SqlServerInitializer.CreateSqlServerSnapshotStoreTables(SnapshotSettings.ConnectionString, SnapshotSettings.SchemaName, SnapshotSettings.TableName);
+                var connectionString = string.IsNullOrEmpty(SnapshotSettings.ConnectionString)
+                    ? ConfigurationManager.ConnectionStrings[SnapshotSettings.ConnectionStringName].ConnectionString
+                    : SnapshotSettings.ConnectionString;
+
+                SqlServerInitializer.CreateSqlServerSnapshotStoreTables(connectionString, SnapshotSettings.SchemaName, SnapshotSettings.TableName);
             }
         }
     }

--- a/src/Akka.Persistence.SqlServer/Journal/QueryBuilder.cs
+++ b/src/Akka.Persistence.SqlServer/Journal/QueryBuilder.cs
@@ -23,7 +23,7 @@ namespace Akka.Persistence.SqlServer.Journal
             _tableName = tableName;
             _schemaName = schemaName;
 
-            _insertMessagesSql = "INSERT INTO {0}.{1} (PersistenceID, SequenceNr, IsDeleted, Manifest, Timestamp, Payload) VALUES (@PersistenceId, @SequenceNr, @IsDeleted, @Manifest, @Timestamp, @Payload)"
+            _insertMessagesSql = "INSERT INTO {0}.{1} (PersistenceID, SequenceNr, IsDeleted, Manifest, Payload, Timestamp) VALUES (@PersistenceId, @SequenceNr, @IsDeleted, @Manifest, @Payload, @Timestamp)"
                 .QuoteSchemaAndTable(_schemaName, _tableName);
             _selectHighestSequenceNrSql = @"SELECT MAX(SequenceNr) FROM {0}.{1} WHERE PersistenceID = @pid".QuoteSchemaAndTable(_schemaName, _tableName);
         }
@@ -37,7 +37,7 @@ namespace Akka.Persistence.SqlServer.Journal
                 .Where(x => !string.IsNullOrEmpty(x));
 
             var where = string.Join(" AND ", sqlized);
-            var sql = new StringBuilder("SELECT PersistenceID, SequenceNr, IsDeleted, Manifest, Timestamp, Payload FROM {0}.{1} ".QuoteSchemaAndTable(_schemaName, _tableName));
+            var sql = new StringBuilder("SELECT PersistenceID, SequenceNr, IsDeleted, Manifest, Payload, Timestamp FROM {0}.{1} ".QuoteSchemaAndTable(_schemaName, _tableName));
             if (!string.IsNullOrEmpty(where))
             {
                 sql.Append(" WHERE ").Append(where);
@@ -170,8 +170,8 @@ namespace Akka.Persistence.SqlServer.Journal
                     SequenceNr,
                     IsDeleted,
                     Manifest,
-                    Timestamp,
-                    Payload ", max != long.MaxValue ? "TOP " + max : string.Empty)
+                    Payload,
+                    Timestamp ", max != long.MaxValue ? "TOP " + max : string.Empty)
                 .Append(" FROM {0}.{1} WHERE PersistenceId = @pid".QuoteSchemaAndTable(_schemaName, _tableName));
 
             // since we guarantee type of fromSequenceNr, toSequenceNr and max

--- a/src/Akka.Persistence.SqlServer/Snapshot/QueryBuilder.cs
+++ b/src/Akka.Persistence.SqlServer/Snapshot/QueryBuilder.cs
@@ -17,9 +17,9 @@ namespace Akka.Persistence.SqlServer.Snapshot
         {
             var schemaName = settings.SchemaName;
             var tableName = settings.TableName;
-            _deleteSql = @"DELETE FROM {0}.{1} WHERE CS_PID = CHECKSUM(@PersistenceId) ".QuoteSchemaAndTable(schemaName, tableName);
+            _deleteSql = @"DELETE FROM {0}.{1} WHERE PersistenceId = @PersistenceId ".QuoteSchemaAndTable(schemaName, tableName);
             _insertSql = @"INSERT INTO {0}.{1} (PersistenceId, SequenceNr, Timestamp, Manifest, Snapshot) VALUES (@PersistenceId, @SequenceNr, @Timestamp, @Manifest, @Snapshot)".QuoteSchemaAndTable(schemaName, tableName);
-            _selectSql = @"SELECT PersistenceId, SequenceNr, Timestamp, Manifest, Snapshot FROM {0}.{1} WHERE CS_PID = CHECKSUM(@PersistenceId)".QuoteSchemaAndTable(schemaName, tableName);
+            _selectSql = @"SELECT PersistenceId, SequenceNr, Timestamp, Manifest, Snapshot FROM {0}.{1} WHERE PersistenceId = @PersistenceId".QuoteSchemaAndTable(schemaName, tableName);
         }
 
         public DbCommand DeleteOne(string persistenceId, long sequenceNr, DateTime timestamp)

--- a/src/Akka.Persistence.SqlServer/Snapshot/SqlServerQueryMapper.cs
+++ b/src/Akka.Persistence.SqlServer/Snapshot/SqlServerQueryMapper.cs
@@ -17,7 +17,7 @@ namespace Akka.Persistence.SqlServer.Snapshot
         {
             var persistenceId = reader.GetString(0);
             var sequenceNr = reader.GetInt64(1);
-            var timestamp = new DateTime(reader.GetInt64(2));
+            var timestamp = reader.GetDateTime(2);
 
             var metadata = new SnapshotMetadata(persistenceId, sequenceNr, timestamp);
             var snapshot = GetSnapshot(reader);

--- a/src/Akka.Persistence.SqlServer/SqlServerInitializer.cs
+++ b/src/Akka.Persistence.SqlServer/SqlServerInitializer.cs
@@ -17,8 +17,8 @@ namespace Akka.Persistence.SqlServer
 	                Payload VARBINARY(MAX) NOT NULL
                     CONSTRAINT PK_{3} PRIMARY KEY (PersistenceID, SequenceNr)
                 );
-                CREATE INDEX IX_{3}_CS_PID ON {0}.{1}(CS_PID);
                 CREATE INDEX IX_{3}_SequenceNr ON {0}.{1}(SequenceNr);
+                CREATE INDEX IX_{3}_Timestamp ON {0}.{1}(Timestamp);
             END
             ";
 
@@ -33,7 +33,6 @@ namespace Akka.Persistence.SqlServer
 	                Snapshot VARBINARY(MAX) NOT NULL
                     CONSTRAINT PK_{3} PRIMARY KEY (PersistenceID, SequenceNr)
                 );
-                CREATE INDEX IX_{3}_CS_PID ON {0}.{1}(CS_PID);
                 CREATE INDEX IX_{3}_SequenceNr ON {0}.{1}(SequenceNr);
                 CREATE INDEX IX_{3}_Timestamp ON {0}.{1}(Timestamp);
             END

--- a/src/Akka.Persistence.SqlServer/packages.config
+++ b/src/Akka.Persistence.SqlServer/packages.config
@@ -1,9 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Akka" version="1.0.5.111-beta" targetFramework="net45" />
-  <package id="Akka.Persistence" version="1.0.5.111-beta" targetFramework="net45" />
-  <package id="Akka.Persistence.Sql.Common" version="1.0.5.111-beta" targetFramework="net45" />
+  <package id="Akka" version="1.0.5" targetFramework="net45" />
+  <package id="Akka.Persistence" version="1.0.5.15-beta" targetFramework="net45" />
+  <package id="Akka.Persistence.Sql.Common" version="1.0.5.15-beta" targetFramework="net45" />
   <package id="Google.ProtocolBuffers" version="2.4.1.521" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
-  <package id="Wire" version="0.0.6" targetFramework="net45" />
 </packages>

--- a/src/Akka.Persistence.SqlServer/sql-server.conf
+++ b/src/Akka.Persistence.SqlServer/sql-server.conf
@@ -23,6 +23,9 @@
 
 			# should corresponding journal table be initialized automatically
 			auto-initialize = off
+			
+			# timestamp provider used for generation of journal entries timestamps
+			timestamp-provider = "Akka.Persistence.Sql.Common.Journal.DefaultTimestampProvider, Akka.Persistence.Sql.Common"
 		}
 	}
 


### PR DESCRIPTION
This PR contains following changes:

- Use Akka releases from major branch (not akka nightly)
- Updated xUnit 2.0 &rArr; 2.1
- Modified database initializer to use either connection string from HOCON of connection string from app.config linked from HOCON name. Also updated database creation script.
- Updated default HOCON config with default timestamp-provider entry specified
- Fixed query builders parameters precedence.
- Added default constructor for `SqlServerJournal`.
- Fully removed CS_PID column, as it didn't serve it's purpose.