### PR TITLE
Enable integration tests running in Docker SQL Server Express container on TeamCity

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -1,10 +1,13 @@
 ﻿#I @"src/packages/FAKE/tools"
 #r "FakeLib.dll"
 #r "System.Xml.Linq"
+#r "System.Managment.Automation"
 
 open System
 open System.IO
 open System.Text
+open System.Management.Automation
+open System.Data.Common
 open Fake
 open Fake.FileUtils
 open Fake.TaskRunnerHelper

--- a/build.fsx
+++ b/build.fsx
@@ -143,6 +143,7 @@ Target "RunTests" <| fun _ ->
 Target "StartDbContainer" <| fun _ -> 
     logfn "Starting SQL Express Docker container..."
     PowerShell.Create()
+        .AddScript(@"Set-ExecutionPolicy Unrestricted -Force")
         .AddScript(@"./docker_sql_express.ps1")
         .Invoke()
         |> Seq.iter (printfn "\t %O")

--- a/build.fsx
+++ b/build.fsx
@@ -128,7 +128,7 @@ Target "CleanTests" <| fun _ ->
 //--------------------------------------------------------------------------------
 // Run tests
 
-open XUnit2Helper
+open Fake.Testing
 Target "RunTests" <| fun _ ->  
     let xunitTestAssemblies = !! "src/**/bin/Release/*.Tests.dll" 
 

--- a/build.fsx
+++ b/build.fsx
@@ -145,7 +145,7 @@ Target "StartDbContainer" <| fun _ ->
         .AddScript(@"./docker_sql_express.ps1")
         .Invoke()
         |> Seq.last
-        |> printfn "SQL Express Docker container IP Address: %O"
+        |> printfn "SQL Express Docker container created with IP address: %O"
 
 Target "PrepAppConfig" <| fun _ -> 
     let ip = environVar "container_ip"
@@ -379,7 +379,9 @@ Target "Help" <| fun _ ->
       " * Build      Builds"
       " * Nuget      Create and optionally publish nugets packages"
       " * RunTests   Runs tests"
+      " * RunTestsWithDocker Runs tests against a Docker container using the microsoft/sql-server-windows-express image"
       " * All        Builds, run tests, creates and optionally publish nuget packages"
+      " * AllWithDockerTests Builds, runs Docker container-based tests, creates and optionally publish nuget packages"
       ""
       " Other Targets"
       " * Help       Display this help" 

--- a/build.fsx
+++ b/build.fsx
@@ -173,6 +173,8 @@ FinalTarget "TearDownDbContainer" <| fun _ ->
     match environVarOrNone "container_name" with
     | Some x -> printfn "container_name is %s" x
     | None -> log ("NO CONTAINER_NAME VARIABLE FOUND")
+
+ActivateFinalTarget "TearDownDbContainer"
     
 //--------------------------------------------------------------------------------
 // Nuget targets 
@@ -464,6 +466,7 @@ Target "HelpDocs" <| fun _ ->
 
 // tests dependencies
 "CleanTests" ==> "StartDbContainer" ==> "PrepAppConfig" ==> "RunTests"
+"TearDownDbContainer" ==> "RunTests"
 
 // nuget dependencies
 "CleanNuget" ==> "CreateNuget"
@@ -476,4 +479,3 @@ Target "All" DoNothing
 
 RunTargetOrDefault "Help"
 
-ActivateFinalTarget "TearDownDbContainer"

--- a/build.fsx
+++ b/build.fsx
@@ -141,12 +141,13 @@ Target "RunTests" <| fun _ ->
         xunitTestAssemblies
 
 Target "StartDbContainer" <| fun _ -> 
+    logfn "Starting SQL Express Docker container..."
     PowerShell.Create()
         .AddScript(@"./docker_sql_express.ps1")
         .Invoke()
-        |> ignore
+        |> Seq.iter (printfn "\t %O")
     match environVarOrNone "container_ip" with
-        | Some x -> logf "SQL Express Docker container created with IP address: %s" x
+        | Some x -> logfn "SQL Express Docker container created with IP address: %s" x
         | None -> failwith "SQL Express Docker container was not started successfully... failing build"
 
 Target "PrepAppConfig" <| fun _ -> 

--- a/build.fsx
+++ b/build.fsx
@@ -1,7 +1,7 @@
 ﻿#I @"src/packages/FAKE/tools"
 #r "FakeLib.dll"
 #r "System.Xml.Linq"
-#r "System.Managment.Automation"
+#r "System.Management.Automation"
 
 open System
 open System.IO

--- a/build.fsx
+++ b/build.fsx
@@ -467,7 +467,10 @@ Target "HelpDocs" <| fun _ ->
 
 // tests dependencies
 "CleanTests" ==> "RunTests"
-"CleanTests" ==> "ActivateFinalTargets" ==> "StartDbContainer" ==> "PrepAppConfig" ==> "RunTestsWithDocker"
+
+// tests with docker dependencies
+Target "RunTestsWithDocker" DoNothing
+"CleanTests" ==> "ActivateFinalTargets" ==> "StartDbContainer" ==> "PrepAppConfig" ==> "RunTests" ==> "RunTestsWithDocker"
 
 // nuget dependencies
 "CleanNuget" ==> "CreateNuget"

--- a/build.fsx
+++ b/build.fsx
@@ -141,9 +141,9 @@ Target "RunTests" <| fun _ ->
         xunitTestAssemblies
 
 Target "StartDbContainer" <| fun _ ->
-    logfn "Starting SQL Express Docker container..."
-
-    let posh = PowerShell.Create().AddScript(@"./docker_sql_express.ps1")
+    let dockerImage = getBuildParamOrDefault "dockerImage" @"microsoft/mssql-server-windows-express"
+    logfn "Starting SQL Express Docker container using image: %s" dockerImage
+    let posh = PowerShell.Create().AddScript(sprintf @"./docker_sql_express.ps1 -dockerImage %s" dockerImage)
     posh.Invoke() |> Seq.iter (logfn "%O")
 
     match posh.HadErrors with

--- a/build.fsx
+++ b/build.fsx
@@ -172,7 +172,7 @@ Target "PrepAppConfig" <| fun _ ->
 FinalTarget "TearDownDbContainer" <| fun _ ->
     match environVarOrNone "container_name" with
     | Some x -> printfn "container_name is %s" x
-    | None -> log ("NO CONTAINER_NAME VARIABLE FOUND")
+    | None -> ()
 
 ActivateFinalTarget "TearDownDbContainer"
     

--- a/build.fsx
+++ b/build.fsx
@@ -151,8 +151,8 @@ Target "PrepAppConfig" <| fun _ ->
     let ip = environVar "container_ip"
     let appConfig = "src/Akka.Persistence.SqlServer.Tests/App.config"
 
-    log (appConfig)
-    log (ip)
+    log appConfig
+    log ip
 
     let configFile = readConfig appConfig
     let connStringNode = configFile.SelectSingleNode "//connectionStrings/add[@name='TestDb']"
@@ -172,11 +172,11 @@ Target "PrepAppConfig" <| fun _ ->
 FinalTarget "TearDownDbContainer" <| fun _ ->
     match environVarOrNone "container_name" with
     | Some x -> let cmd = sprintf "docker stop %s; docker rm %s" x x
-                log (cmd)
-//                PowerShell.Create()
-//                    .AddScript(cmd)
-//                    .Invoke()
-//                    |> ignore
+                logf "Killing container: %s" x
+                PowerShell.Create()
+                    .AddScript(cmd)
+                    .Invoke()
+                    |> ignore
     | None -> ()
 
 Target "ActivateFinalTargets"  <| fun _ ->

--- a/build.fsx
+++ b/build.fsx
@@ -174,7 +174,8 @@ FinalTarget "TearDownDbContainer" <| fun _ ->
     | Some x -> printfn "container_name is %s" x
     | None -> ()
 
-ActivateFinalTarget "TearDownDbContainer"
+Target "ActivateFinalTargets"  <| fun _ ->
+    ActivateFinalTarget "TearDownDbContainer"
     
 //--------------------------------------------------------------------------------
 // Nuget targets 
@@ -465,8 +466,8 @@ Target "HelpDocs" <| fun _ ->
 "Clean" ==> "AssemblyInfo" ==> "RestorePackages" ==> "UpdateDependencies" ==> "Build" ==> "CopyOutput" ==> "BuildRelease"
 
 // tests dependencies
-"CleanTests" ==> "StartDbContainer" ==> "PrepAppConfig" ==> "RunTests"
-"TearDownDbContainer" ==> "RunTests"
+"CleanTests" ==> "RunTests"
+"CleanTests" ==> "ActivateFinalTargets" ==> "StartDbContainer" ==> "PrepAppConfig" ==> "RunTestsWithDocker"
 
 // nuget dependencies
 "CleanNuget" ==> "CreateNuget"
@@ -476,6 +477,11 @@ Target "All" DoNothing
 "BuildRelease" ==> "All"
 "RunTests" ==> "All"
 "Nuget" ==> "All"
+
+Target "AllWithDockerTests" DoNothing
+"BuildRelease" ==> "AllWithDockerTests"
+"RunTestsWithDocker" ==> "AllWithDockerTests"
+"Nuget" ==> "AllWithDockerTests"
 
 RunTargetOrDefault "Help"
 

--- a/build.fsx
+++ b/build.fsx
@@ -137,7 +137,7 @@ Target "RunTests" <| fun _ ->
     let xunitToolPath = findToolInSubPath "xunit.console.exe" "src/packages/xunit.runner.console*/tools"
     printfn "Using XUnit runner: %s" xunitToolPath
     xUnit2
-        (fun p -> { p with OutputDir = testOutput; ToolPath = xunitToolPath })
+        (fun p -> { p with HtmlOutputPath = Some(testOutput @@ "xunit.html") })
         xunitTestAssemblies
 
 Target "StartDbContainer" <| fun _ -> 

--- a/build.fsx
+++ b/build.fsx
@@ -171,7 +171,12 @@ Target "PrepAppConfig" <| fun _ ->
 
 FinalTarget "TearDownDbContainer" <| fun _ ->
     match environVarOrNone "container_name" with
-    | Some x -> printfn "container_name is %s" x
+    | Some x -> let cmd = sprintf "docker stop %s; docker rm %s" x x
+                log (cmd)
+//                PowerShell.Create()
+//                    .AddScript(cmd)
+//                    .Invoke()
+//                    |> ignore
     | None -> ()
 
 Target "ActivateFinalTargets"  <| fun _ ->

--- a/build.fsx
+++ b/build.fsx
@@ -140,16 +140,20 @@ Target "RunTests" <| fun _ ->
         (fun p -> { p with HtmlOutputPath = Some(testOutput @@ "xunit.html") })
         xunitTestAssemblies
 
-Target "StartDbContainer" <| fun _ -> 
+Target "StartDbContainer" <| fun _ ->
     logfn "Starting SQL Express Docker container..."
-    PowerShell.Create()
-        .AddScript(@"Set-ExecutionPolicy Unrestricted -Force")
-        .AddScript(@"./docker_sql_express.ps1")
-        .Invoke()
-        |> Seq.iter (printfn "\t %O")
+
+    let posh = PowerShell.Create().AddScript(@"./docker_sql_express.ps1")
+    posh.Invoke() |> Seq.iter (logfn "%O")
+
+    match posh.HadErrors with
+    | true -> posh.Streams.Error |> Seq.iter (logfn "\t %O")
+              failwith "SQL Express Docker container startup encountered an error... failing build"
+    | false -> ()
+
     match environVarOrNone "container_ip" with
-        | Some x -> logfn "SQL Express Docker container created with IP address: %s" x
-        | None -> failwith "SQL Express Docker container was not started successfully... failing build"
+    | Some x -> logfn "SQL Express Docker container created with IP address: %s" x
+    | None -> failwith "SQL Express Docker container env:container_ip not set... failing build"
 
 Target "PrepAppConfig" <| fun _ -> 
     let ip = environVarOrNone "container_ip"
@@ -185,7 +189,7 @@ FinalTarget "TearDownDbContainer" <| fun _ ->
 
 Target "ActivateFinalTargets"  <| fun _ ->
     ActivateFinalTarget "TearDownDbContainer"
-    
+
 //--------------------------------------------------------------------------------
 // Nuget targets 
 //--------------------------------------------------------------------------------

--- a/build.fsx
+++ b/build.fsx
@@ -144,8 +144,10 @@ Target "StartDbContainer" <| fun _ ->
     PowerShell.Create()
         .AddScript(@"./docker_sql_express.ps1")
         .Invoke()
-        |> Seq.last
-        |> printfn "SQL Express Docker container created with IP address: %O"
+        |> ignore
+    match environVarOrNone "container_name" with
+        | Some x -> logf "SQL Express Docker container created with IP address: %s" x
+        | None -> failwith "SQL Express Docker container was not started successfully... failing build"
 
 Target "PrepAppConfig" <| fun _ -> 
     let ip = environVar "container_ip"

--- a/build.fsx
+++ b/build.fsx
@@ -172,7 +172,7 @@ Target "PrepAppConfig" <| fun _ ->
 FinalTarget "TearDownDbContainer" <| fun _ ->
     match environVarOrNone "container_name" with
     | Some x -> printfn "container_name is %s" x
-    | None -> ()
+    | None -> log ("NO CONTAINER_NAME VARIABLE FOUND")
     
 //--------------------------------------------------------------------------------
 // Nuget targets 

--- a/build.fsx
+++ b/build.fsx
@@ -153,9 +153,6 @@ Target "PrepAppConfig" <| fun _ ->
     let ip = environVar "container_ip"
     let appConfig = "src/Akka.Persistence.SqlServer.Tests/App.config"
 
-    log appConfig
-    log ip
-
     let configFile = readConfig appConfig
     let connStringNode = configFile.SelectSingleNode "//connectionStrings/add[@name='TestDb']"
     let connString = connStringNode.Attributes.["connectionString"].Value

--- a/build.fsx
+++ b/build.fsx
@@ -151,7 +151,7 @@ Target "PrepAppConfig" <| fun _ ->
     let ip = environVar "container_ip"
     let appConfig = "src/Akka.Persistence.SqlServer.Tests/App.config"
 
-    log(appConfig)
+    log (appConfig)
     log (ip)
 
     let configFile = readConfig appConfig
@@ -169,6 +169,11 @@ Target "PrepAppConfig" <| fun _ ->
     updateConnectionString "TestDb" (newConnString.ToString()) appConfig
     CopyFile "src/Akka.Persistence.SqlServer.Tests/bin/Release/Akka.Persistence.SqlServer.Tests.dll.config" appConfig
 
+FinalTarget "TearDownDbContainer" <| fun _ ->
+    match environVarOrNone "container_name" with
+    | Some x -> printfn "container_name is %s" x
+    | None -> ()
+    
 //--------------------------------------------------------------------------------
 // Nuget targets 
 //--------------------------------------------------------------------------------
@@ -470,3 +475,5 @@ Target "All" DoNothing
 "Nuget" ==> "All"
 
 RunTargetOrDefault "Help"
+
+ActivateFinalTarget "TearDownDbContainer"

--- a/docker_sql_express.ps1
+++ b/docker_sql_express.ps1
@@ -1,18 +1,17 @@
-#IF ($(docker ps -aq -f label=deployer=akkadotnet).Length -gt 0) {
-#    docker stop $(docker ps -aq -f label=deployer=akkadotnet)
-#    docker rm $(docker ps -aq -f label=deployer=akkadotnet)
-#}
-#Write-Host "Starting SQL Server Express Docker container..."
-#$env:container_name = "akka-$(New-Guid)"
-#$container_id = docker run -d --name $env:container_name -l deployer=akkadotnet -p 1433:1433 -e ACCEPT_EULA=Y microsoft/mssql-server-windows-express
-#Start-Sleep -Seconds 30
-#docker exec $container_id sqlcmd -q "CREATE LOGIN akkadotnet with password='akkadotnet', CHECK_POLICY=OFF; ALTER SERVER ROLE dbcreator ADD MEMBER akkadotnet;"
-#$env:container_ip = docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $container_id
-#Write-Host "SQL container started at IP addr: $($env:container_ip)"
+param(
+	[Parameter(Mandatory=$true)]
+	[string]$dockerImage
+)
 
 IF ($(docker ps -aq -f label=deployer=akkadotnet).Length -gt 0) {
     docker stop $(docker ps -aq -f label=deployer=akkadotnet)
     docker rm $(docker ps -aq -f label=deployer=akkadotnet)
 }
+
+Write-Host "Starting SQL Server Express Docker container..."
 $env:container_name = "akka-$(New-Guid)"
-docker run -it --name $env:container_name -l deployer=akkadotnet -p 1433:1433 -e ACCEPT_EULA=Y microsoft/mssql-server-windows-express
+$container_id = docker run -d --name $env:container_name -l deployer=akkadotnet -p 1433:1433 -e ACCEPT_EULA=Y $dockerImage
+Start-Sleep -Seconds 30
+docker exec $container_id sqlcmd -q "CREATE LOGIN akkadotnet with password='akkadotnet', CHECK_POLICY=OFF; ALTER SERVER ROLE dbcreator ADD MEMBER akkadotnet;"
+$env:container_ip = docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $container_id
+Write-Host "SQL container started at IP addr: $($env:container_ip)"

--- a/docker_sql_express.ps1
+++ b/docker_sql_express.ps1
@@ -1,10 +1,11 @@
-IF ($(docker ps -aq).Length -gt 0) {
-    docker stop $(docker ps -aq)
-    docker rm $(docker ps -aq)
+IF ($(docker ps -aq -f label=deployer=akkadotnet).Length -gt 0) {
+    docker stop $(docker ps -aq -f label=deployer=akkadotnet)
+    docker rm $(docker ps -aq -f label=deployer=akkadotnet)
 }
-Write-Host "Starting docker container..."
-$container_id = docker run -d -p 1433:1433 -e sa_password=G!a7eZZM -e ACCEPT_EULA=Y microsoft/mssql-server-windows-express 
+Write-Host "Starting SQL Server Express Docker container..."
+$env:container_name = "akka-$(New-Guid)"
+$container_id = docker run -d --name $env:container_name -l deployer=akkadotnet -p 1433:1433 -e ACCEPT_EULA=Y microsoft/mssql-server-windows-express
 Start-Sleep -Seconds 30
 docker exec $container_id sqlcmd -q "CREATE LOGIN akkadotnet with password='akkadotnet', CHECK_POLICY=OFF; ALTER SERVER ROLE dbcreator ADD MEMBER akkadotnet;"
 $env:container_ip = docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $container_id
-$env:container_ip
+Write-Host "SQL container started at IP addr: $($env:container_ip)"

--- a/docker_sql_express.ps1
+++ b/docker_sql_express.ps1
@@ -14,4 +14,5 @@ IF ($(docker ps -aq -f label=deployer=akkadotnet).Length -gt 0) {
     docker stop $(docker ps -aq -f label=deployer=akkadotnet)
     docker rm $(docker ps -aq -f label=deployer=akkadotnet)
 }
+$env:container_name = "akka-$(New-Guid)"
 docker run -it --name $env:container_name -l deployer=akkadotnet -p 1433:1433 -e ACCEPT_EULA=Y microsoft/mssql-server-windows-express

--- a/docker_sql_express.ps1
+++ b/docker_sql_express.ps1
@@ -1,0 +1,10 @@
+IF ($(docker ps -aq).Length -gt 0) {
+    docker stop $(docker ps -aq)
+    docker rm $(docker ps -aq)
+}
+Write-Host "Starting docker container..."
+$container_id = docker run -d -p 1433:1433 -e sa_password=G!a7eZZM -e ACCEPT_EULA=Y microsoft/mssql-server-windows-express 
+Start-Sleep -Seconds 30
+docker exec $container_id sqlcmd -q "CREATE LOGIN akkadotnet with password='akkadotnet', CHECK_POLICY=OFF; ALTER SERVER ROLE dbcreator ADD MEMBER akkadotnet;"
+$env:container_ip = docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $container_id
+$env:container_ip

--- a/docker_sql_express.ps1
+++ b/docker_sql_express.ps1
@@ -1,11 +1,17 @@
+#IF ($(docker ps -aq -f label=deployer=akkadotnet).Length -gt 0) {
+#    docker stop $(docker ps -aq -f label=deployer=akkadotnet)
+#    docker rm $(docker ps -aq -f label=deployer=akkadotnet)
+#}
+#Write-Host "Starting SQL Server Express Docker container..."
+#$env:container_name = "akka-$(New-Guid)"
+#$container_id = docker run -d --name $env:container_name -l deployer=akkadotnet -p 1433:1433 -e ACCEPT_EULA=Y microsoft/mssql-server-windows-express
+#Start-Sleep -Seconds 30
+#docker exec $container_id sqlcmd -q "CREATE LOGIN akkadotnet with password='akkadotnet', CHECK_POLICY=OFF; ALTER SERVER ROLE dbcreator ADD MEMBER akkadotnet;"
+#$env:container_ip = docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $container_id
+#Write-Host "SQL container started at IP addr: $($env:container_ip)"
+
 IF ($(docker ps -aq -f label=deployer=akkadotnet).Length -gt 0) {
     docker stop $(docker ps -aq -f label=deployer=akkadotnet)
     docker rm $(docker ps -aq -f label=deployer=akkadotnet)
 }
-Write-Host "Starting SQL Server Express Docker container..."
-$env:container_name = "akka-$(New-Guid)"
-$container_id = docker run -d --name $env:container_name -l deployer=akkadotnet -p 1433:1433 -e ACCEPT_EULA=Y microsoft/mssql-server-windows-express
-Start-Sleep -Seconds 30
-docker exec $container_id sqlcmd -q "CREATE LOGIN akkadotnet with password='akkadotnet', CHECK_POLICY=OFF; ALTER SERVER ROLE dbcreator ADD MEMBER akkadotnet;"
-$env:container_ip = docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $container_id
-Write-Host "SQL container started at IP addr: $($env:container_ip)"
+docker run -it --name $env:container_name -l deployer=akkadotnet -p 1433:1433 -e ACCEPT_EULA=Y microsoft/mssql-server-windows-express

--- a/src/Akka.Persistence.SqlServer.Tests/app.config
+++ b/src/Akka.Persistence.SqlServer.Tests/app.config
@@ -1,8 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <connectionStrings>
-    <!--<add name="TestDb" connectionString="Data Source=localhost\SQLEXPRESS;Database=akka_persistence_tests;User Id=akkadotnet;Password=akkadotnet;" />-->
-    <add name="TestDb" connectionString="Data Source=.;Database=akka_persistence_tests;Trusted_Connection=Yes;" />
+     <add name="TestDb" connectionString="Data Source=localhost\SQLEXPRESS;Database=akka_persistence_tests;User Id=akkadotnet;Password=akkadotnet;" />
   </connectionStrings>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">


### PR DESCRIPTION
This PR enables the integration tests to run on Windows Server 2016 w/Containers using Microsoft's [mssql-server-windows-express](https://hub.docker.com/r/microsoft/mssql-server-windows-express/) base image.  Using FAKE, it handles `docker run` of the container and then alters the App.config so that the tests can issue commands to the SQL Server Express instance inside the container.  It will then tear-down the container per run of the FAKE build.  The build target is run using the `.\build.cmd AllWithDockerTests` command.