### PR TITLE
Add ByTagSql override taking into account @Take parameter

### DIFF
--- a/src/Akka.Persistence.SqlServer/Journal/SqlServerQueryExecutor.cs
+++ b/src/Akka.Persistence.SqlServer/Journal/SqlServerQueryExecutor.cs
@@ -16,6 +16,19 @@ namespace Akka.Persistence.SqlServer.Journal
         public SqlServerQueryExecutor(QueryConfiguration configuration, Akka.Serialization.Serialization serialization, ITimestampProvider timestampProvider)
             : base(configuration, serialization, timestampProvider)
         {
+            ByTagSql = $@"
+            SELECT TOP (@Take)
+            e.{Configuration.PersistenceIdColumnName} as PersistenceId, 
+            e.{Configuration.SequenceNrColumnName} as SequenceNr, 
+            e.{Configuration.TimestampColumnName} as Timestamp, 
+            e.{Configuration.IsDeletedColumnName} as IsDeleted, 
+            e.{Configuration.ManifestColumnName} as Manifest, 
+            e.{Configuration.PayloadColumnName} as Payload,
+            e.{Configuration.OrderingColumnName} as Ordering
+            FROM {Configuration.FullJournalTableName} e
+            WHERE e.{Configuration.OrderingColumnName} > @Ordering AND e.{Configuration.TagsColumnName} LIKE @Tag
+            ORDER BY {Configuration.OrderingColumnName} ASC
+            ";
             CreateEventsJournalSql = $@"
             IF NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '{configuration.SchemaName}' AND TABLE_NAME = '{configuration.JournalEventsTableName}')
             BEGIN
@@ -47,7 +60,8 @@ namespace Akka.Persistence.SqlServer.Journal
         }
 
         protected override DbCommand CreateCommand(DbConnection connection) => new SqlCommand { Connection = (SqlConnection)connection };
-        
+
+        protected override string ByTagSql { get; }
         protected override string CreateEventsJournalSql { get; }
         protected override string CreateMetaTableSql { get; }
     }


### PR DESCRIPTION
`AbstractQueryExecutor` provides a [default implementation for `ByTagSql`](https://github.com/akkadotnet/akka.net/blob/dev/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/QueryExecutor.cs#L330-L335) which does not use [`@Take` parameter passed into command](https://github.com/akkadotnet/akka.net/blob/dev/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/QueryExecutor.cs#L484). As a result, all events matching a tag will be fetched from DB when replay is requested, which becomes problematic when there is a lot of them (in our case, ~900k).

This PR overrides `ByTagSql` so that it limits result count with `@Take` parameter.

[Compare Sqlite implementation](https://github.com/akkadotnet/akka.net/blob/dev/src/contrib/persistence/Akka.Persistence.Sqlite/Journal/SqliteQueryExecutor.cs#L28)