### PR TITLE
Revert making manifest column nullable

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ CREATE TABLE {your_journal_table_name} (
   SequenceNr BIGINT NOT NULL,
   Timestamp BIGINT NOT NULL,
   IsDeleted BIT NOT NULL,
-  Manifest NVARCHAR(500) NULL,
+  Manifest NVARCHAR(500) NOT NULL,
   Payload VARBINARY(MAX) NOT NULL,
   Tags NVARCHAR(100) NULL,
   SerializerId INTEGER NULL
@@ -93,7 +93,7 @@ CREATE TABLE {your_snapshot_table_name} (
   PersistenceID NVARCHAR(255) NOT NULL,
   SequenceNr BIGINT NOT NULL,
   Timestamp DATETIME2 NOT NULL,
-  Manifest NVARCHAR(500) NULL,
+  Manifest NVARCHAR(500) NOT NULL,
   Snapshot VARBINARY(MAX) NOT NULL,
   SerializerId INTEGER NULL
   CONSTRAINT PK_{your_snapshot_table_name} PRIMARY KEY (PersistenceID, SequenceNr)

--- a/src/Akka.Persistence.SqlServer/Journal/SqlServerQueryExecutor.cs
+++ b/src/Akka.Persistence.SqlServer/Journal/SqlServerQueryExecutor.cs
@@ -39,7 +39,7 @@ namespace Akka.Persistence.SqlServer.Journal
 	                {configuration.SequenceNrColumnName} BIGINT NOT NULL,
                     {configuration.TimestampColumnName} BIGINT NOT NULL,
                     {configuration.IsDeletedColumnName} BIT NOT NULL,
-                    {configuration.ManifestColumnName} NVARCHAR(500) NULL,
+                    {configuration.ManifestColumnName} NVARCHAR(500) NOT NULL,
 	                {configuration.PayloadColumnName} VARBINARY(MAX) NOT NULL,
                     {configuration.TagsColumnName} NVARCHAR(100) NULL,
                     {configuration.SerializerIdColumnName} INTEGER NULL,

--- a/src/Akka.Persistence.SqlServer/Snapshot/SqlServerQueryExecutor.cs
+++ b/src/Akka.Persistence.SqlServer/Snapshot/SqlServerQueryExecutor.cs
@@ -22,7 +22,7 @@ namespace Akka.Persistence.SqlServer.Snapshot
 	                {configuration.PersistenceIdColumnName} NVARCHAR(255) NOT NULL,
 	                {configuration.SequenceNrColumnName} BIGINT NOT NULL,
                     {configuration.TimestampColumnName} DATETIME2 NOT NULL,
-                    {configuration.ManifestColumnName} NVARCHAR(500) NULL,
+                    {configuration.ManifestColumnName} NVARCHAR(500) NOT NULL,
 	                {configuration.PayloadColumnName} VARBINARY(MAX) NOT NULL,
                     {configuration.SerializerIdColumnName} INTEGER NULL
                     CONSTRAINT PK_{configuration.SnapshotTableName} PRIMARY KEY ({configuration.PersistenceIdColumnName}, {configuration.SequenceNrColumnName})


### PR DESCRIPTION
Validated that it isn't necessary to have the `Manifest` column nullable per issue #77 and not necessary for the migration path.  Reverting the previous change.