### PR TITLE
Enable Serialization Specs

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -136,7 +136,7 @@ Target "CleanTests" <| fun _ ->
 // Run tests
 
 open Fake.Testing
-Target "RunTests" <| fun _ ->  
+Target "RunTests" <| fun _ ->
     let projects = 
         match (isWindows) with 
         | true -> !! "./src/**/*.Tests.csproj"
@@ -145,11 +145,17 @@ Target "RunTests" <| fun _ ->
     ensureDirectory outputTests
 
     let runSingleProject project =
-        DotNetCli.Test
-                (fun p -> 
-                    { p with
-                        Project = project
-                        Configuration = configuration })
+        let result = ExecProcess(fun info ->
+            info.FileName <- "dotnet"
+            info.WorkingDirectory <- (Directory.GetParent project).FullName
+            info.Arguments <- (sprintf "xunit -f net452 -c Release -parallel none -xml %s_xunit.xml" (outputTests @@ fileNameWithoutExt project))) (TimeSpan.FromMinutes 30.)
+        
+        ResultHandling.failBuildIfXUnitReportedError TestRunnerErrorLevel.DontFailBuild result
+
+        // dotnet process will be killed by ExecProcess (or throw if can't) '
+        // but per https://github.com/xunit/xunit/issues/1338 xunit.console may not
+        killProcess "xunit.console"
+        killProcess "dotnet"
 
     projects |> Seq.iter (log)
     projects |> Seq.iter (runSingleProject)

--- a/build.fsx
+++ b/build.fsx
@@ -135,7 +135,6 @@ Target "CleanTests" <| fun _ ->
 //--------------------------------------------------------------------------------
 // Run tests
 
-open Fake.Testing
 Target "RunTests" <| fun _ ->
     let projects = 
         match (isWindows) with 
@@ -148,7 +147,31 @@ Target "RunTests" <| fun _ ->
         let result = ExecProcess(fun info ->
             info.FileName <- "dotnet"
             info.WorkingDirectory <- (Directory.GetParent project).FullName
-            info.Arguments <- (sprintf "xunit -f net452 -c Release -parallel none -xml %s_xunit.xml" (outputTests @@ fileNameWithoutExt project))) (TimeSpan.FromMinutes 30.)
+            info.Arguments <- (sprintf "xunit -f net452 -c Release -parallel none -xml %s_net452_xunit.xml" (outputTests @@ fileNameWithoutExt project))) (TimeSpan.FromMinutes 30.)
+        
+        ResultHandling.failBuildIfXUnitReportedError TestRunnerErrorLevel.DontFailBuild result
+
+        // dotnet process will be killed by ExecProcess (or throw if can't) '
+        // but per https://github.com/xunit/xunit/issues/1338 xunit.console may not
+        killProcess "xunit.console"
+        killProcess "dotnet"
+
+    projects |> Seq.iter (log)
+    projects |> Seq.iter (runSingleProject)
+
+Target "RunTestsNetCore" <| fun _ ->
+    let projects = 
+        match (isWindows) with 
+        | true -> !! "./src/**/*.Tests.csproj"
+        | _ -> !! "./src/**/*.Tests.csproj" // if you need to filter specs for Linux vs. Windows, do it here
+
+    ensureDirectory outputTests
+
+    let runSingleProject project =
+        let result = ExecProcess(fun info ->
+            info.FileName <- "dotnet"
+            info.WorkingDirectory <- (Directory.GetParent project).FullName
+            info.Arguments <- (sprintf "xunit -f netcoreapp1.1 -c Release -parallel none -xml %s_netcore_xunit.xml" (outputTests @@ fileNameWithoutExt project))) (TimeSpan.FromMinutes 30.)
         
         ResultHandling.failBuildIfXUnitReportedError TestRunnerErrorLevel.DontFailBuild result
 
@@ -386,7 +409,7 @@ Target "HelpDocs" <| fun _ ->
 
 // tests with docker dependencies
 Target "RunTestsWithDocker" DoNothing
-"CleanTests" ==> "ActivateFinalTargets" ==> "StartDbContainer" ==> "PrepAppConfig" ==> "RunTests" ==> "RunTestsWithDocker"
+"CleanTests" ==> "ActivateFinalTargets" ==> "StartDbContainer" ==> "PrepAppConfig" ==> "RunTests" ==> "RunTestsNetCore" ==> "RunTestsWithDocker"
 
 // nuget dependencies
 "BuildRelease" ==> "CreateNuget" ==> "Nuget"

--- a/src/Akka.Persistence.SqlServer.Tests/AppConfig.xml
+++ b/src/Akka.Persistence.SqlServer.Tests/AppConfig.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <connectionStrings>
-    <add name="TestDb" connectionString="data source=172.20.218.106;database=akka_persistence_tests;user id=akkadotnet;password=akkadotnet" />
+    <add name="TestDb" connectionString="data source=172.20.216.100;database=akka_persistence_tests;user id=akkadotnet;password=akkadotnet" />
   </connectionStrings>
 </configuration>

--- a/src/Akka.Persistence.SqlServer.Tests/AppConfig.xml
+++ b/src/Akka.Persistence.SqlServer.Tests/AppConfig.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <connectionStrings>
-    <add name="TestDb" connectionString="data source=172.20.216.100;database=akka_persistence_tests;user id=akkadotnet;password=akkadotnet" />
+    <add name="TestDb" connectionString="data source=.;database=akka_persistence_tests;user id=akkadotnet;password=akkadotnet" />
   </connectionStrings>
 </configuration>

--- a/src/Akka.Persistence.SqlServer.Tests/Serialization/SqlServerJournalSerializationSpec.cs
+++ b/src/Akka.Persistence.SqlServer.Tests/Serialization/SqlServerJournalSerializationSpec.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Akka.Configuration;
+using Akka.Persistence.TCK.Serialization;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.SqlServer.Tests.Serialization
+{
+    public class SqlServerJournalSerializationSpec : JournalSerializationSpec
+    {
+        private static readonly Config SpecConfig;
+
+        static SqlServerJournalSerializationSpec()
+        {
+            DbUtils.Initialize();
+            var specString = @"
+                akka.persistence {
+                    publish-plugin-commands = on
+                    journal {
+                        plugin = ""akka.persistence.journal.sql-server""
+                        sql-server {
+                            event-adapters {
+                                custom-adapter = ""Akka.Persistence.TCK.Serialization.TestJournal+MyWriteAdapter, Akka.Persistence.TCK""
+                            }
+                            event-adapter-bindings = {
+                                ""Akka.Persistence.TCK.Serialization.TestJournal+MyPayload3, Akka.Persistence.TCK"" = custom-adapter
+                            }    
+                            class = ""Akka.Persistence.SqlServer.Journal.SqlServerJournal, Akka.Persistence.SqlServer""
+                            plugin-dispatcher = ""akka.actor.default-dispatcher""
+                            table-name = EventJournal
+                            metadata-table-name = Metadata
+                            schema-name = dbo
+                            auto-initialize = on
+                            connection-string = """ + DbUtils.ConnectionString + @"""
+                        }
+                    }
+                }";
+
+            SpecConfig = ConfigurationFactory.ParseString(specString);
+        }
+
+        public SqlServerJournalSerializationSpec(ITestOutputHelper output) : base(SpecConfig, "SqlServerJournalSerializationSpec", output)
+        {            
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            DbUtils.Clean();
+        }
+
+        [Fact(Skip = "Sql plugin does not support EventAdapter.Manifest")]
+        public override void Journal_should_serialize_Persistent_with_EventAdapter_manifest()
+        {
+        }
+    }
+}

--- a/src/Akka.Persistence.SqlServer.Tests/Serialization/SqlServerSnapshotSerializationSpec.cs
+++ b/src/Akka.Persistence.SqlServer.Tests/Serialization/SqlServerSnapshotSerializationSpec.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Akka.Configuration;
+using Akka.Persistence.TCK.Serialization;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.SqlServer.Tests.Serialization
+{
+    public class SqlServerSnapshotSerializationSpec : SnapshotStoreSerializationSpec
+    {
+        private static readonly Config SpecConfig;
+
+        static SqlServerSnapshotSerializationSpec()
+        {
+            DbUtils.Initialize();
+            var specString = @"
+                akka.persistence {
+                    publish-plugin-commands = on
+                    snapshot-store {
+                        plugin = ""akka.persistence.snapshot-store.sql-server""
+                        sql-server {
+                            class = ""Akka.Persistence.SqlServer.Snapshot.SqlServerSnapshotStore, Akka.Persistence.SqlServer""
+                            plugin-dispatcher = ""akka.actor.default-dispatcher""
+                            table-name = SnapshotStore
+                            auto-initialize = on
+                            connection-string = """ + DbUtils.ConnectionString + @"""
+                        }
+                    }
+                }";
+            SpecConfig = ConfigurationFactory.ParseString(specString);
+        }
+
+        public SqlServerSnapshotSerializationSpec(ITestOutputHelper output) : base(SpecConfig, "SqlServerSnapshotSerializationSpec", output)
+        {
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            DbUtils.Clean();
+        }
+    }
+}


### PR DESCRIPTION
Turns on Serialization Specs and also updates build script to use `dotnet xunit` instead of `dotnet test`