### PR TITLE
Update to Akka 1.3.7

### DIFF
--- a/src/Akka.Persistence.SqlServer.Tests/Akka.Persistence.SqlServer.Tests.csproj
+++ b/src/Akka.Persistence.SqlServer.Tests/Akka.Persistence.SqlServer.Tests.csproj
@@ -7,7 +7,7 @@
       <PackageTags>akka;actors;actor model;Akka;concurrency;SQL;SQL Server</PackageTags>
       <Copyright>Copyright © 2013-2017 Akka.NET Team</Copyright>
       <Authors>Akka.NET Team</Authors>
-      <VersionPrefix>1.3.0</VersionPrefix>
+      <VersionPrefix>1.3.7</VersionPrefix>
       <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
       <PackageProjectUrl>https://github.com/akkadotnet/Akka.Persistence.SqlServer</PackageProjectUrl>
       <PackageLicenseUrl>https://github.com/akkadotnet/Akka.Persistence.SqlServer/blob/master/LICENSE</PackageLicenseUrl>
@@ -20,12 +20,12 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-      <PackageReference Include="Akka" Version="1.3.2" />
-      <PackageReference Include="Akka.Persistence" Version="1.3.2" />
-      <PackageReference Include="Akka.Persistence.Sql.Common" Version="1.3.2" />
-      <PackageReference Include="Akka.Persistence.Sql.TestKit" Version="1.3.1" />
-      <PackageReference Include="Akka.TestKit" Version="1.3.2" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+      <PackageReference Include="Akka" Version="1.3.7" />
+      <PackageReference Include="Akka.Persistence" Version="1.3.7" />
+      <PackageReference Include="Akka.Persistence.Sql.Common" Version="1.3.7" />
+      <PackageReference Include="Akka.Persistence.Sql.TestKit" Version="1.3.7" />
+      <PackageReference Include="Akka.TestKit" Version="1.3.7" />
       <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.2" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="1.1.2" />
       <PackageReference Include="xunit" Version="$(XunitVersion)" />

--- a/src/Akka.Persistence.SqlServer/Akka.Persistence.SqlServer.csproj
+++ b/src/Akka.Persistence.SqlServer/Akka.Persistence.SqlServer.csproj
@@ -8,7 +8,7 @@
     <PackageTags>akka;actors;actor model;Akka;concurrency;SQL;SQL Server</PackageTags>
     <Copyright>Copyright © 2013-2017 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.3.1</VersionPrefix>
+    <VersionPrefix>1.3.7</VersionPrefix>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/Akka.Persistence.SqlServer</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/Akka.Persistence.SqlServer/blob/master/LICENSE</PackageLicenseUrl>
@@ -29,9 +29,15 @@ ALTER TABLE {your_snapshot_table_name} ADD COLUMN SerializerId INTEGER NULL
     <EmbeddedResource Include="sql-server.conf" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Akka" Version="1.3.2" />
-    <PackageReference Include="Akka.Persistence" Version="1.3.2" />
-    <PackageReference Include="Akka.Persistence.Sql.Common" Version="1.3.2" />
+    <PackageReference Include="Akka" Version="1.3.7" />
+    <PackageReference Include="Akka.Persistence" Version="1.3.7" />
+    <PackageReference Include="Akka.Persistence.Sql.Common" Version="1.3.7" />
+    <PackageReference Include="Akka.TestKit" Version="1.3.7" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
+    <PackageReference Include="Akka.Persistence.Sql.TestKit">
+      <Version>1.3.7</Version>
+    </PackageReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>

--- a/src/Akka.Persistence.SqlServer/Journal/BatchingSqlServerJournal.cs
+++ b/src/Akka.Persistence.SqlServer/Journal/BatchingSqlServerJournal.cs
@@ -24,7 +24,8 @@ namespace Akka.Persistence.SqlServer.Journal
                     orderingColumnName: "Ordering",
                     serializerIdColumnName: "SerializerId",
                     timeout: config.GetTimeSpan("connection-timeout", TimeSpan.FromSeconds(30)),
-                    defaultSerializer: config.GetString("serializer")))
+                    defaultSerializer: config.GetString("serializer"),
+                    useSequentialAccess: config.GetBoolean("sequential-access")))
         {
         }
 

--- a/src/Akka.Persistence.SqlServer/Journal/SqlServerJournal.cs
+++ b/src/Akka.Persistence.SqlServer/Journal/SqlServerJournal.cs
@@ -32,7 +32,8 @@ namespace Akka.Persistence.SqlServer.Journal
                 orderingColumnName: "Ordering",
                 serializerIdColumnName: "SerializerId",
                 timeout: config.GetTimeSpan("connection-timeout"),
-                defaultSerializer: config.GetString("serializer")),
+                defaultSerializer: config.GetString("serializer"),
+                useSequentialAccess: config.GetBoolean("sequential-access")),
                     Context.System.Serialization,
                     GetTimestampProvider(config.GetString("timestamp-provider")));
         }

--- a/src/Akka.Persistence.SqlServer/Snapshot/SqlServerSnapshotStore.cs
+++ b/src/Akka.Persistence.SqlServer/Snapshot/SqlServerSnapshotStore.cs
@@ -29,7 +29,8 @@ namespace Akka.Persistence.SqlServer.Snapshot
                 timestampColumnName: "Timestamp",
                 serializerIdColumnName: "SerializerId",
                 timeout: sqlConfig.GetTimeSpan("connection-timeout"),
-                defaultSerializer: config.GetString("serializer")),
+                defaultSerializer: config.GetString("serializer"),
+                useSequentialAccess: config.GetBoolean("sequential-access")),
                 
                 Context.System.Serialization);
         }

--- a/src/Akka.Persistence.SqlServer/sql-server.conf
+++ b/src/Akka.Persistence.SqlServer/sql-server.conf
@@ -27,6 +27,8 @@
 
 			# metadata table
 			metadata-table-name = Metadata
+
+			sequential-access = off
 		}
 	}
 
@@ -53,6 +55,8 @@
 
 			# should corresponding journal table be initialized automatically
 			auto-initialize = off
+
+			sequential-access = off
 		}
 	}
 }


### PR DESCRIPTION
This updates the project references to Akka 1.3.7 and implements the
changes introduced into Akka.Persistence.Sql.Common
(useSequentialAccess)