### PR TITLE
v1.3.7 Akka.Persistence.SqlServer Release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ tools/
 
 #VS
 .vs/
+.dotnet/
 
 #MonoDevelop
 *.userprefs

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,11 @@
+#### 1.3.7 June 04 2018 ####
+Upgrades to Akka.Persistence 1.3.7, which includes some major changes for SQL-based SnapShot stores, which you can read more about here: https://github.com/akkadotnet/akka.net/issues/3422
+
+This should significantly improve the performance of SQL-based journals for loading large snapshots.
+
+Also, removes the dependency on the Akka.TestKit for this package.
+
+
 #### 1.3.2 October 29 2017 ####
 
 Updated to Akka.Persistence v1.3.2. Fixed bug in SnapshotStore query.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+#### 1.3.2 October 29 2017 ####
+
+Updated to Akka.Persistence v1.3.2. Fixed bug in SnapshotStore query.
+
 #### 1.3.1 September 11 2017 ####
 
 Support for Akka.NET 1.3, .NET Standard 1.6, and the first stable RTM release of Akka.Persistence.

--- a/src/Akka.Persistence.SqlServer.Tests/Akka.Persistence.SqlServer.Tests.csproj
+++ b/src/Akka.Persistence.SqlServer.Tests/Akka.Persistence.SqlServer.Tests.csproj
@@ -7,7 +7,7 @@
       <PackageTags>akka;actors;actor model;Akka;concurrency;SQL;SQL Server</PackageTags>
       <Copyright>Copyright © 2013-2017 Akka.NET Team</Copyright>
       <Authors>Akka.NET Team</Authors>
-      <VersionPrefix>1.3.0</VersionPrefix>
+      <VersionPrefix>1.3.7</VersionPrefix>
       <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
       <PackageProjectUrl>https://github.com/akkadotnet/Akka.Persistence.SqlServer</PackageProjectUrl>
       <PackageLicenseUrl>https://github.com/akkadotnet/Akka.Persistence.SqlServer/blob/master/LICENSE</PackageLicenseUrl>
@@ -20,12 +20,12 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-      <PackageReference Include="Akka" Version="1.3.2" />
-      <PackageReference Include="Akka.Persistence" Version="1.3.2" />
-      <PackageReference Include="Akka.Persistence.Sql.Common" Version="1.3.2" />
-      <PackageReference Include="Akka.Persistence.Sql.TestKit" Version="1.3.1" />
-      <PackageReference Include="Akka.TestKit" Version="1.3.2" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+      <PackageReference Include="Akka" Version="1.3.7" />
+      <PackageReference Include="Akka.Persistence" Version="1.3.7" />
+      <PackageReference Include="Akka.Persistence.Sql.Common" Version="1.3.7" />
+      <PackageReference Include="Akka.Persistence.Sql.TestKit" Version="1.3.7" />
+      <PackageReference Include="Akka.TestKit" Version="1.3.7" />
       <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.2" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="1.1.2" />
       <PackageReference Include="xunit" Version="$(XunitVersion)" />
@@ -39,5 +39,9 @@
 
     <ItemGroup>
       <ProjectReference Include="..\Akka.Persistence.SqlServer\Akka.Persistence.SqlServer.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
     </ItemGroup>
 </Project>

--- a/src/Akka.Persistence.SqlServer/Akka.Persistence.SqlServer.csproj
+++ b/src/Akka.Persistence.SqlServer/Akka.Persistence.SqlServer.csproj
@@ -8,7 +8,7 @@
     <PackageTags>akka;actors;actor model;Akka;concurrency;SQL;SQL Server</PackageTags>
     <Copyright>Copyright © 2013-2017 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.3.1</VersionPrefix>
+    <VersionPrefix>1.3.7</VersionPrefix>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/Akka.Persistence.SqlServer</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/Akka.Persistence.SqlServer/blob/master/LICENSE</PackageLicenseUrl>
@@ -29,9 +29,11 @@ ALTER TABLE {your_snapshot_table_name} ADD COLUMN SerializerId INTEGER NULL
     <EmbeddedResource Include="sql-server.conf" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Akka" Version="1.3.2" />
-    <PackageReference Include="Akka.Persistence" Version="1.3.2" />
-    <PackageReference Include="Akka.Persistence.Sql.Common" Version="1.3.2" />
+    <PackageReference Include="Akka" Version="1.3.7" />
+    <PackageReference Include="Akka.Persistence" Version="1.3.7" />
+    <PackageReference Include="Akka.Persistence.Sql.Common" Version="1.3.7" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
   </ItemGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>

--- a/src/Akka.Persistence.SqlServer/Akka.Persistence.SqlServer.csproj
+++ b/src/Akka.Persistence.SqlServer/Akka.Persistence.SqlServer.csproj
@@ -12,13 +12,9 @@
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/Akka.Persistence.SqlServer</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/Akka.Persistence.SqlServer/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageReleaseNotes>Support for Akka.NET 1.3, .NET Standard 1.6, and the first stable RTM release of Akka.Persistence.
-Migration from 1.1.1.7-beta Up**
-The event journal and snapshot store schema has changed with this release.  In order to keep existing stores compatible with this release, you **must** add a column to both stores for `SerializerId` like so:
-```sql
-ALTER TABLE {your_journal_table_name} ADD COLUMN SerializerId INTEGER NULL
-ALTER TABLE {your_snapshot_table_name} ADD COLUMN SerializerId INTEGER NULL
-```</PackageReleaseNotes>
+    <PackageReleaseNotes>Upgrades to Akka.Persistence 1.3.7, which includes some major changes for SQL-based SnapShot stores, which you can read more about here: https://github.com/akkadotnet/akka.net/issues/3422
+This should significantly improve the performance of SQL-based journals for loading large snapshots.
+Also, removes the dependency on the Akka.TestKit for this package.</PackageReleaseNotes>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
   </PropertyGroup>

--- a/src/Akka.Persistence.SqlServer/Journal/BatchingSqlServerJournal.cs
+++ b/src/Akka.Persistence.SqlServer/Journal/BatchingSqlServerJournal.cs
@@ -24,7 +24,8 @@ namespace Akka.Persistence.SqlServer.Journal
                     orderingColumnName: "Ordering",
                     serializerIdColumnName: "SerializerId",
                     timeout: config.GetTimeSpan("connection-timeout", TimeSpan.FromSeconds(30)),
-                    defaultSerializer: config.GetString("serializer")))
+                    defaultSerializer: config.GetString("serializer"),
+                    useSequentialAccess: config.GetBoolean("sequential-access")))
         {
         }
 

--- a/src/Akka.Persistence.SqlServer/Journal/SqlServerJournal.cs
+++ b/src/Akka.Persistence.SqlServer/Journal/SqlServerJournal.cs
@@ -32,7 +32,8 @@ namespace Akka.Persistence.SqlServer.Journal
                 orderingColumnName: "Ordering",
                 serializerIdColumnName: "SerializerId",
                 timeout: config.GetTimeSpan("connection-timeout"),
-                defaultSerializer: config.GetString("serializer")),
+                defaultSerializer: config.GetString("serializer"),
+                useSequentialAccess: config.GetBoolean("sequential-access")),
                     Context.System.Serialization,
                     GetTimestampProvider(config.GetString("timestamp-provider")));
         }

--- a/src/Akka.Persistence.SqlServer/Snapshot/SqlServerSnapshotStore.cs
+++ b/src/Akka.Persistence.SqlServer/Snapshot/SqlServerSnapshotStore.cs
@@ -29,7 +29,8 @@ namespace Akka.Persistence.SqlServer.Snapshot
                 timestampColumnName: "Timestamp",
                 serializerIdColumnName: "SerializerId",
                 timeout: sqlConfig.GetTimeSpan("connection-timeout"),
-                defaultSerializer: config.GetString("serializer")),
+                defaultSerializer: config.GetString("serializer"),
+                useSequentialAccess: config.GetBoolean("sequential-access")),
                 
                 Context.System.Serialization);
         }

--- a/src/Akka.Persistence.SqlServer/sql-server.conf
+++ b/src/Akka.Persistence.SqlServer/sql-server.conf
@@ -27,6 +27,8 @@
 
 			# metadata table
 			metadata-table-name = Metadata
+
+			sequential-access = on
 		}
 	}
 
@@ -53,6 +55,8 @@
 
 			# should corresponding journal table be initialized automatically
 			auto-initialize = off
+
+			sequential-access = on
 		}
 	}
 }


### PR DESCRIPTION
#### 1.3.7 June 04 2018 ####
Upgrades to Akka.Persistence 1.3.7, which includes some major changes for SQL-based SnapShot stores, which you can read more about here: https://github.com/akkadotnet/akka.net/issues/3422

This should significantly improve the performance of SQL-based journals for loading large snapshots.

Also, removes the dependency on the Akka.TestKit for this package.
