### PR TITLE
Akka.Persistence.SqlServer 1.3.13 Release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+#### 1.3.13 April 30 2019 ####
+* Upgrades to Akka.Persistence v1.3.13
+* Resolves https://github.com/akkadotnet/Akka.Persistence.SqlServer/issues/104 - major issue with BatchingSqlJournal.
+
 #### 1.3.7 June 04 2018 ####
 Upgrades to Akka.Persistence 1.3.7, which includes some major changes for SQL-based SnapShot stores, which you can read more about here: https://github.com/akkadotnet/akka.net/issues/3422
 

--- a/build.ps1
+++ b/build.ps1
@@ -34,7 +34,7 @@ $NBenchVersion = "0.3.4"
 $DotNetChannel = "preview";
 $DotNetVersion = "1.0.4";
 $DotNetInstallerUri = "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1";
-$NugetVersion = "3.5.0";
+$NugetVersion = "4.3.0";
 $NugetUrl = "https://dist.nuget.org/win-x86-commandline/v$NugetVersion/nuget.exe"
 
 # Make sure tools folder exists

--- a/src/Akka.Persistence.SqlServer.Tests/Akka.Persistence.SqlServer.Tests.csproj
+++ b/src/Akka.Persistence.SqlServer.Tests/Akka.Persistence.SqlServer.Tests.csproj
@@ -7,7 +7,7 @@
       <PackageTags>akka;actors;actor model;Akka;concurrency;SQL;SQL Server</PackageTags>
       <Copyright>Copyright © 2013-2017 Akka.NET Team</Copyright>
       <Authors>Akka.NET Team</Authors>
-      <VersionPrefix>1.3.7</VersionPrefix>
+      <VersionPrefix>1.3.12</VersionPrefix>
       <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
       <PackageProjectUrl>https://github.com/akkadotnet/Akka.Persistence.SqlServer</PackageProjectUrl>
       <PackageLicenseUrl>https://github.com/akkadotnet/Akka.Persistence.SqlServer/blob/master/LICENSE</PackageLicenseUrl>
@@ -21,11 +21,8 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
-      <PackageReference Include="Akka" Version="1.3.7" />
-      <PackageReference Include="Akka.Persistence" Version="1.3.7" />
-      <PackageReference Include="Akka.Persistence.Sql.Common" Version="1.3.7" />
-      <PackageReference Include="Akka.Persistence.Sql.TestKit" Version="1.3.7" />
-      <PackageReference Include="Akka.TestKit" Version="1.3.7" />
+      <PackageReference Include="Akka.Persistence.Sql.Common" Version="1.3.12" />
+      <PackageReference Include="Akka.Persistence.Sql.TestKit" Version="1.3.12" />
       <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.2" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="1.1.2" />
       <PackageReference Include="xunit" Version="$(XunitVersion)" />

--- a/src/Akka.Persistence.SqlServer.Tests/Akka.Persistence.SqlServer.Tests.csproj
+++ b/src/Akka.Persistence.SqlServer.Tests/Akka.Persistence.SqlServer.Tests.csproj
@@ -21,8 +21,8 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
-      <PackageReference Include="Akka.Persistence.Sql.Common" Version="1.3.12" />
-      <PackageReference Include="Akka.Persistence.Sql.TestKit" Version="1.3.12" />
+      <PackageReference Include="Akka.Persistence.Sql.Common" Version="1.3.13" />
+      <PackageReference Include="Akka.Persistence.Sql.TestKit" Version="1.3.13" />
       <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.2" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="1.1.2" />
       <PackageReference Include="xunit" Version="$(XunitVersion)" />
@@ -36,9 +36,5 @@
 
     <ItemGroup>
       <ProjectReference Include="..\Akka.Persistence.SqlServer\Akka.Persistence.SqlServer.csproj" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
     </ItemGroup>
 </Project>

--- a/src/Akka.Persistence.SqlServer/Akka.Persistence.SqlServer.csproj
+++ b/src/Akka.Persistence.SqlServer/Akka.Persistence.SqlServer.csproj
@@ -3,18 +3,19 @@
   <Import Project="..\common.props" />
   <PropertyGroup>
     <AssemblyTitle>Akka.Persistence.SqlServer</AssemblyTitle>
-    <Description>Akka Persistence journal and snapshot store backed by SQL Server database.</Description>
+    <Description>#### 1.3.13 April 30 2019 ####
+* Upgrades to Akka.Persistence v1.3.13
+* Resolves https://github.com/akkadotnet/Akka.Persistence.SqlServer/issues/104 - major issue with BatchingSqlJournal.</Description>
     <TargetFrameworks>net45;netstandard1.6</TargetFrameworks>
     <PackageTags>akka;actors;actor model;Akka;concurrency;SQL;SQL Server</PackageTags>
-    <Copyright>Copyright © 2013-2017 Akka.NET Team</Copyright>
+    <Copyright>Copyright © 2013-2019 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.3.12</VersionPrefix>
+    <VersionPrefix>1.3.13</VersionPrefix>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/Akka.Persistence.SqlServer</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/Akka.Persistence.SqlServer/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageReleaseNotes>Upgrades to Akka.Persistence 1.3.12, which includes some major changes for SQL-based SnapShot stores, which you can read more about here: https://github.com/akkadotnet/akka.net/issues/3422
-This should significantly improve the performance of SQL-based journals for loading large snapshots.
-Also, removes the dependency on the Akka.TestKit for this package.</PackageReleaseNotes>
+    <PackageReleaseNotes>Upgrades to Akka.Persistence v1.3.13
+Resolves https://github.com/akkadotnet/Akka.Persistence.SqlServer/issues/104 - major issue with BatchingSqlJournal.</PackageReleaseNotes>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
   </PropertyGroup>

--- a/src/Akka.Persistence.SqlServer/Akka.Persistence.SqlServer.csproj
+++ b/src/Akka.Persistence.SqlServer/Akka.Persistence.SqlServer.csproj
@@ -25,7 +25,7 @@ Also, removes the dependency on the Akka.TestKit for this package.</PackageRelea
     <EmbeddedResource Include="sql-server.conf" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Akka.Persistence.Sql.Common" Version="1.3.12" />
+    <PackageReference Include="Akka.Persistence.Sql.Common" Version="1.3.13" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
   </ItemGroup>

--- a/src/Akka.Persistence.SqlServer/Akka.Persistence.SqlServer.csproj
+++ b/src/Akka.Persistence.SqlServer/Akka.Persistence.SqlServer.csproj
@@ -8,11 +8,11 @@
     <PackageTags>akka;actors;actor model;Akka;concurrency;SQL;SQL Server</PackageTags>
     <Copyright>Copyright © 2013-2017 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.3.7</VersionPrefix>
+    <VersionPrefix>1.3.12</VersionPrefix>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/Akka.Persistence.SqlServer</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/Akka.Persistence.SqlServer/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageReleaseNotes>Upgrades to Akka.Persistence 1.3.7, which includes some major changes for SQL-based SnapShot stores, which you can read more about here: https://github.com/akkadotnet/akka.net/issues/3422
+    <PackageReleaseNotes>Upgrades to Akka.Persistence 1.3.12, which includes some major changes for SQL-based SnapShot stores, which you can read more about here: https://github.com/akkadotnet/akka.net/issues/3422
 This should significantly improve the performance of SQL-based journals for loading large snapshots.
 Also, removes the dependency on the Akka.TestKit for this package.</PackageReleaseNotes>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -25,9 +25,7 @@ Also, removes the dependency on the Akka.TestKit for this package.</PackageRelea
     <EmbeddedResource Include="sql-server.conf" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Akka" Version="1.3.7" />
-    <PackageReference Include="Akka.Persistence" Version="1.3.7" />
-    <PackageReference Include="Akka.Persistence.Sql.Common" Version="1.3.7" />
+    <PackageReference Include="Akka.Persistence.Sql.Common" Version="1.3.12" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
   </ItemGroup>

--- a/src/common.props
+++ b/src/common.props
@@ -3,7 +3,7 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
-    <XunitVersion>2.3.0-beta5-*</XunitVersion>
+    <XunitVersion>2.3.1</XunitVersion>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">


### PR DESCRIPTION
#### 1.3.13 April 30 2019 ####
* Upgrades to Akka.Persistence v1.3.13
* Resolves https://github.com/akkadotnet/Akka.Persistence.SqlServer/issues/104 - major issue with BatchingSqlJournal.