### PR TITLE
added v1.3.17 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,9 @@
+#### 1.3.17 January 20 2020 ####
+* Upgrades to Akka.Persistence v1.3.17.
+* Upgrades to latest SqlClient.
+* [Resolved: Generated SQL creates a large number of cached query plans in SQL Server](https://github.com/akkadotnet/akka.net/issues/4141)
+
+
 #### 1.3.14 July 30 2019 ####
 * Upgrades to Akka.Persistence v1.3.14 - resolves major issues with Akka.Cluster.Sharding serialization.
 * [BatchingSqlJournal now preserves Sender in PersistCallback](https://github.com/akkadotnet/akka.net/pull/3779)

--- a/src/common.props
+++ b/src/common.props
@@ -2,12 +2,13 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-2019 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.3.14</VersionPrefix>
+    <VersionPrefix>1.3.17</VersionPrefix>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/Akka.Persistence.SqlServer</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/Akka.Persistence.SqlServer/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageReleaseNotes>Upgrades to Akka.Persistence v1.3.14 - resolves major issues with Akka.Cluster.Sharding serialization.
-[BatchingSqlJournal now preserves Sender in PersistCallback](https://github.com/akkadotnet/akka.net/pull/3779)</PackageReleaseNotes>
+    <PackageReleaseNotes>Upgrades to Akka.Persistence v1.3.17.
+Upgrades to latest SqlClient.
+[Resolved: Generated SQL creates a large number of cached query plans in SQL Server](https://github.com/akkadotnet/akka.net/issues/4141)</PackageReleaseNotes>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
#### 1.3.17 January 20 2020 ####
* Upgrades to Akka.Persistence v1.3.17.
* Upgrades to latest SqlClient.
* [Resolved: Generated SQL creates a large number of cached query plans in SQL Server](https://github.com/akkadotnet/akka.net/issues/4141)
