### PR TITLE
Add documentation and warning logging for dangerous circuit breaker Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Both journal and snapshot store share the same configuration keys (however they 
 
 Remember that connection string must be provided separately to Journal and Snapshot Store.
 
+Please also note that unless circuit breaker settings are configured, the defaults from Akka.Persistence will be used. If these defaults are less than the Database connection timeout (default or provided in connection string) and provided command timeout, Warnings will be logged upon initialization of the Journal or Snapshot Store.
+
 ```hocon
 akka.persistence{
 	journal {
@@ -39,6 +41,10 @@ akka.persistence{
 
 			# metadata table
 			metadata-table-name = Metadata
+			
+			# Recommended: change default circuit breaker settings
+			# By uncommenting below and using Connection Timeout + Command Timeout
+			# circuit-breaker.call-timeout=30s
 		}
 	}
 
@@ -66,6 +72,10 @@ akka.persistence{
 
 			# should corresponding journal table be initialized automatically
 			auto-initialize = off
+			
+			# Recommended: change default circuit breaker settings
+			# By uncommenting below and using Connection Timeout + Command Timeout
+			# circuit-breaker.call-timeout=30s
 		}
 	}
 }

--- a/src/Akka.Persistence.SqlServer/sql-server.conf
+++ b/src/Akka.Persistence.SqlServer/sql-server.conf
@@ -31,8 +31,8 @@
 			sequential-access = on
 			
 			# Recommended: change default circuit breaker settings
-            # By uncommenting below and using Connection Timeout + Command Timeout
-            # circuit-breaker.call-timeout=30s
+			# By uncommenting below and using Connection Timeout + Command Timeout
+			# circuit-breaker.call-timeout=30s
 		}
 	}
 
@@ -63,8 +63,8 @@
 			sequential-access = on
 			
 			# Recommended: change default circuit breaker settings
-            # By uncommenting below and using Connection Timeout + Command Timeout
-            # circuit-breaker.call-timeout=30s
+			# By uncommenting below and using Connection Timeout + Command Timeout
+			# circuit-breaker.call-timeout=30s
 		}
 	}
 }

--- a/src/Akka.Persistence.SqlServer/sql-server.conf
+++ b/src/Akka.Persistence.SqlServer/sql-server.conf
@@ -29,6 +29,10 @@
 			metadata-table-name = Metadata
 
 			sequential-access = on
+			
+			# Recommended: change default circuit breaker settings
+            # By uncommenting below and using Connection Timeout + Command Timeout
+            # circuit-breaker.call-timeout=30s
 		}
 	}
 
@@ -57,6 +61,10 @@
 			auto-initialize = off
 
 			sequential-access = on
+			
+			# Recommended: change default circuit breaker settings
+            # By uncommenting below and using Connection Timeout + Command Timeout
+            # circuit-breaker.call-timeout=30s
 		}
 	}
 }


### PR DESCRIPTION
This PR helps resolve #161 By doing the following:

 - Updating documentation and sample HOCONs (both in Readme.MD and sql-server.conf)

 - Checking settings upon initialization of `SqlServerJournal`, `BatchingSqlServerJournal`, and `SqlSnapshotStore` and logging a warning message if the total Connection+Command timeout are greater than the Circuit breaker timeout.