### PR TITLE
Update RELEASE_NOTES.md for 1.5.13 release

### DIFF
--- a/Akka.Persistence.SqlServer.sln
+++ b/Akka.Persistence.SqlServer.sln
@@ -11,6 +11,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{D8BAD8E8
 		src\Directory.Build.props = src\Directory.Build.props
 		src\Directory.Packages.props = src\Directory.Packages.props
 		build.ps1 = build.ps1
+		README.md = README.md
+		RELEASE_NOTES.md = RELEASE_NOTES.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{85A25CFE-0B51-45FC-9C5E-271F9557F8D3}"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,9 @@
+#### 1.5.13 April 24 2023 ####
+
+* [Update Akka.NET to v1.5.13](https://github.com/akkadotnet/akka.net/releases/tag/1.5.13)
+* [Update snapshot SQL to prevent deadlock](https://github.com/akkadotnet/Akka.Persistence.SqlServer/pull/319)
+* [Update Akka.Hosting version to 1.5.13](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.13)
+
 #### 1.5.4 April 24 2023 ####
 
 * [Update Akka.NET to v1.5.4](https://github.com/akkadotnet/akka.net/releases/tag/1.5.4)


### PR DESCRIPTION
## 1.5.13 April 24 2023 

* [Update Akka.NET to v1.5.13](https://github.com/akkadotnet/akka.net/releases/tag/1.5.13)
* [Update snapshot SQL to prevent deadlock](https://github.com/akkadotnet/Akka.Persistence.SqlServer/pull/319)
* [Update Akka.Hosting version to 1.5.13](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.13)
