### PR TITLE
Bump AkkaVersion and AkkaHostingVersion to 1.5.15

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <AkkaVersion>1.5.13</AkkaVersion>
-    <AkkaHostingVersion>1.5.13</AkkaHostingVersion>
+    <AkkaVersion>1.5.15</AkkaVersion>
+    <AkkaHostingVersion>1.5.15</AkkaHostingVersion>
   </PropertyGroup>
   <!-- App dependencies -->
   <ItemGroup>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -19,8 +19,8 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageVersion Include="xunit" Version="2.5.1" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageVersion Include="xunit" Version="2.5.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.6" />
     <PackageVersion Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
     <PackageVersion Include="Akka.Persistence.Sql.TestKit" Version="$(AkkaVersion)" />
     <PackageVersion Include="Akka.Persistence.TCK" Version="$(AkkaVersion)" />


### PR DESCRIPTION
## Changes

* Bump AkkaVersion to 1.5.15
* Bump AkkaHostingVersion to 1.5.15
* Bump xunit to 2.5.3 (minimum version required by Akka.NET)
* Bump xunit.runner.visualstudio to 2.5.6 (minimum version required by Akka.NET)