### PR TITLE
Bump AkkaVersion and AkkaHostingVersion to 1.5.29

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <AkkaVersion>1.5.28</AkkaVersion>
-    <AkkaHostingVersion>1.5.28</AkkaHostingVersion>
+    <AkkaVersion>1.5.29</AkkaVersion>
+    <AkkaHostingVersion>1.5.29</AkkaHostingVersion>
   </PropertyGroup>
   <!-- App dependencies -->
   <ItemGroup>


### PR DESCRIPTION
> [!NOTE]
>
> Need to wait until Akka.Hosting 1.5.29 is available in NuGet.org to pass CI/CD